### PR TITLE
fix: don't crash when skeleton can't provide org name

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -174,12 +174,13 @@ async function promptForSetUpSkeleton(): Promise<SkeletonAnswers> {
         skeleton,
       }: {
         name: string,
-        skeleton: string,
+        skeleton: ?string,
       }): ?string => {
         const match = /^@(.*?)\//.exec(name)
         if (match) return match[1]
+        if (!skeleton) return undefined
         const parts = skeleton.split(/\//g)
-        if (parts.length >= 2) return parts[parts.length - 2]
+        return parts.length >= 2 ? parts[parts.length - 2] : undefined
       },
       message: 'GitHub organization:',
       validate: required,


### PR DESCRIPTION
I was getting a crash when the skeleton variable ends up undefined when trying to calculate the default.